### PR TITLE
Add Dockerfile-prod for deployment via niployments

### DIFF
--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -1,0 +1,29 @@
+#Based on the template from niployments (https://github.com/NIAEFEUP/niployments) for react applications
+
+# First, building the static files
+FROM node:10.17.0-alpine as build
+
+WORKDIR /usr/src/app
+COPY package.json package-lock.json ./
+
+# Because colors break logs
+ENV NPM_CONFIG_COLOR=false
+
+# Production or not doesn't really matter as this image will not be used other than for building
+RUN npm install
+
+# Necessary files for building the app
+COPY public/ public/
+COPY config/ config/
+COPY scripts/ scripts/
+COPY src/ src/
+
+# Building the image
+RUN npm run build
+
+# Then, use nginx to serve the built files
+# See https://hub.docker.com/_/nginx
+FROM nginx:alpine
+
+# Copying the built files into the nginx image, to the default served directory
+COPY --from=build /usr/src/app/build /usr/share/nginx/html

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "10.16.0"
+    "node": "10.17.0"
   },
   "dependencies": {
     "@babel/core": "7.5.5",


### PR DESCRIPTION
Closes #32

Added Dockerfile based on the template available on niployments for react applications, and added specific folders to the image (config/ and scripts/). 

.env not added because it's not being used for now and is not necessary at the moment. In the future, this might be updated.

The current image serves the build with nginx on port 80 (default) - this needs to be remapped when running probably