### PR TITLE
Add copy .env instruction to Dockerfile-prod

### DIFF
--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -21,6 +21,9 @@ COPY src/ src/
 # Building the image
 RUN npm run build
 
+# Copy env files
+COPY .env* ./
+
 # Then, use nginx to serve the built files
 # See https://hub.docker.com/_/nginx
 FROM nginx:alpine


### PR DESCRIPTION
In order for the app to read PUBLIC_URL var, it needs to have .env files specifying in order to deploy it