### PR TITLE
Add variable basename on router based on env var

### DIFF
--- a/src/AppRouter.js
+++ b/src/AppRouter.js
@@ -4,7 +4,7 @@ import HomePage from "./pages/HomePage";
 import NotFound from "./pages/NotFound";
 
 const AppRouter = () => (
-    <BrowserRouter>
+    <BrowserRouter basename={`${process.env.REACT_APP_BASE_ROUTE || "/"}`}>
         <Switch>
             <Route
                 exact


### PR DESCRIPTION
This allows us to set up the base url of different environments without breaking the router (prod will be on ni.fe.up.pt/nijobs, but dev will be on ni.fe.u.pt/nijobs/st4g1ng)