### PR TITLE
Added a flex wrapper to center SearchArea in MainView

### DIFF
--- a/src/components/HomePage/MainView.js
+++ b/src/components/HomePage/MainView.js
@@ -21,12 +21,14 @@ const MainView = ({ scrollToProductDescription, showSearchResults }) => {
                     />
                 </div>
             </div>
-            <div className={classes.searchArea}>
-                <SearchArea
-                    onSubmit={() => {
-                        showSearchResults();
-                    }}
-                />
+            <div className={classes.searchAreaWrapper}>
+                <div className={classes.searchArea}>
+                    <SearchArea
+                        onSubmit={() => {
+                            showSearchResults();
+                        }}
+                    />
+                </div>
             </div>
             <div className={classes.infoBox}>
                 <InfoBox

--- a/src/components/HomePage/mainViewStyles.js
+++ b/src/components/HomePage/mainViewStyles.js
@@ -25,10 +25,16 @@ export default makeStyles(() => ({
             width: "50%",
         },
     },
-    searchArea: {
-        width: "100%",
+    searchAreaWrapper: {
+        width: "100vw",
+        height: "100vh",
         position: "absolute",
-        top: "42.5vh",
+        top: 0,
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+    },
+    searchArea: {
         "& > *:first-child": {
             width: "60%",
             margin: "0 auto",


### PR DESCRIPTION
This is something that was not easily noticeable, unless you use uncommon resolutions (my viewport is usually 1920*2160 - like two 1080p screens on top of each other), which made the search area go to places where it shouldn't.

It should be fixed now, I simply added a flex wrapper that centers the search area vertically.
---
Before:
![nijobs_b4](https://user-images.githubusercontent.com/28157246/69083375-e46d3f80-0a39-11ea-8ff2-879066050f7e.png)

After:
![nijobs_after](https://user-images.githubusercontent.com/28157246/69083386-e931f380-0a39-11ea-9ecf-4bd4f377fed5.png)

