### PR TITLE
Wrapped SearchArea in a CenteredComponent

### DIFF
--- a/src/components/HomePage/MainView.js
+++ b/src/components/HomePage/MainView.js
@@ -11,6 +11,7 @@ import { useMobile, useDesktop } from "../../utils/media-queries";
 
 import useMainViewStyles from "./mainViewStyles.js";
 import { MainMask } from "./MainMask";
+import CenteredComponent from "./CenteredComponent";
 
 const MainView = ({ scrollToProductDescription, showSearchResults }) => {
 
@@ -25,13 +26,15 @@ const MainView = ({ scrollToProductDescription, showSearchResults }) => {
                     />
                 </div>
             </MainMask>
-            <div className={classes.searchArea}>
-                <SearchArea
-                    onSubmit={() => {
-                        showSearchResults();
-                    }}
-                />
-            </div>
+            <CenteredComponent>
+                <div className={classes.searchArea}>
+                    <SearchArea
+                        onSubmit={() => {
+                            showSearchResults();
+                        }}
+                    />
+                </div>
+            </CenteredComponent>
             <div className={classes.infoBox}>
                 <InfoBox size={useMobile() ? "small" : "normal"}>
                     Your next oportunity is out there. Use the search bar to find it!

--- a/src/components/HomePage/mainViewStyles.js
+++ b/src/components/HomePage/mainViewStyles.js
@@ -23,7 +23,8 @@ export default makeStyles((theme) => ({
     searchArea: ({ isMobile }) => ({
         width: "100%",
         position: "absolute",
-        top: "42.5vh",
+        top: "calc(50vh - 80px)",
+        left: 0,
         "& > *:first-child": {
             width: isMobile ? "100%" : "60%",
             margin: "0 auto",


### PR DESCRIPTION
This addresses the problem solved in #41, but in the correct way, using the `CenteredComponent`

This is something that was not easily noticeable unless you use uncommon resolutions (my viewport is usually 1920*2160 - like two 1080p screens on top of each other), which made the search area go to places where it shouldn't.

It should be fixed now, I simply added a flex wrapper that centers the search area vertically.
---
Before:
![nijobs_b4](https://user-images.githubusercontent.com/28157246/69083375-e46d3f80-0a39-11ea-8ff2-879066050f7e.png)

After:
![nijobs_after](https://user-images.githubusercontent.com/28157246/69083386-e931f380-0a39-11ea-9ecf-4bd4f377fed5.png)

