### PR TITLE
Changed link to react router link

### DIFF
--- a/src/components/Apply/Company/ApplicationConfirmation.js
+++ b/src/components/Apply/Company/ApplicationConfirmation.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { RouterLink } from "../../../utils";
 import { Card, CardHeader, CardContent, CardActions, Link, Typography, makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
@@ -30,11 +31,11 @@ const ApplicationConfirmation = () => {
                 </Typography>
             </CardContent>
             <CardActions className={classes.actions}>
-                <Link
-                    href="/"
+                <RouterLink
+                    to="/"
                 >
                 Go to Homepage
-                </Link>
+                </RouterLink>
             </CardActions>
         </Card>
     );

--- a/src/pages/CompanyApplicationPage.spec.js
+++ b/src/pages/CompanyApplicationPage.spec.js
@@ -4,6 +4,7 @@ import CompanyApplicationPage from "./CompanyApplicationPage";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { createMuiTheme } from "@material-ui/core";
+import { BrowserRouter as Router } from "react-router-dom";
 
 describe("CompanyApplicationPage", () => {
 

--- a/src/pages/CompanyApplicationPage.spec.js
+++ b/src/pages/CompanyApplicationPage.spec.js
@@ -54,7 +54,7 @@ describe("CompanyApplicationPage", () => {
             const wrapper = renderWithStoreAndTheme(
                 <Router>
                     <CompanyApplicationPage showConfirmation/>
-                </Router>, 
+                </Router>,
                 { store, theme }
             );
             expect(wrapper.getByText("Application Submitted")).toBeTruthy();

--- a/src/pages/CompanyApplicationPage.spec.js
+++ b/src/pages/CompanyApplicationPage.spec.js
@@ -50,7 +50,12 @@ describe("CompanyApplicationPage", () => {
         });
 
         it("should render a confirmation dialog on registration completion", () => {
-            const wrapper = renderWithStoreAndTheme(<CompanyApplicationPage showConfirmation/>, { store, theme });
+            const wrapper = renderWithStoreAndTheme(
+                <Router>
+                    <CompanyApplicationPage showConfirmation/>
+                </Router>, 
+                { store, theme }
+            );
             expect(wrapper.getByText("Application Submitted")).toBeTruthy();
 
         });


### PR DESCRIPTION
Changed link to react-router link when returning to homepage from a application submission to fix the problem in Prod where the root directory is different.

Closes #65 