### PR TITLE
Enabled auto-mocking of fetch by default on tests

### DIFF
--- a/config/jest/setup.js
+++ b/config/jest/setup.js
@@ -5,7 +5,7 @@ import "@testing-library/jest-dom";
 import { enableFetchMocks } from "jest-fetch-mock";
 
 enableFetchMocks();
-fetchMock.dontMock();
+fetchMock.doMock();
 
 // Mock localStorage
 Object.defineProperty(window, "localStorage", {

--- a/src/components/Apply/Company/CompanyApplicationForm.spec.js
+++ b/src/components/Apply/Company/CompanyApplicationForm.spec.js
@@ -147,7 +147,6 @@ describe("CompanyApplicationForm", () => {
         it("should show submission error after submit", async () => {
 
             // Simulate network problem
-            fetchMock.doMock();
             fetch.mockAbort();
 
             const wrapper = renderWithStoreAndTheme(<CompanyApplicationForm />, { store, theme });
@@ -239,7 +238,6 @@ describe("CompanyApplicationForm", () => {
     it("should clear submission error after changing some input", async () => {
 
         // Simulate network problem
-        fetchMock.doMock();
         fetch.mockAbort();
 
         const companyName = "valid company name";
@@ -295,7 +293,6 @@ describe("CompanyApplicationForm", () => {
     it("should show a confirmation screen after submission success", async () => {
 
         // Simulate request success
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ mockData: true }));
 
         const companyName = "valid company name";

--- a/src/components/HomePage/MainView.spec.js
+++ b/src/components/HomePage/MainView.spec.js
@@ -55,6 +55,9 @@ describe("Main View", () => {
         });
 
         it("should call showSearchResults when search is submitted", () => {
+            // Simulate request success
+            fetch.mockResponse(JSON.stringify({ mockData: true }));
+
             wrapper.find("form#search_form").first().simulate("submit", {
                 preventDefault: () => {},
             });

--- a/src/components/HomePage/SearchArea/SearchArea.spec.js
+++ b/src/components/HomePage/SearchArea/SearchArea.spec.js
@@ -95,6 +95,10 @@ describe("SearchArea", () => {
         it("should call onSubmit callback on form submit", () => {
             const addSnackbar = () => {};
             const searchOffersMock = jest.fn();
+
+            // Simulate request success
+            fetch.mockResponse(JSON.stringify({ mockData: true }));
+
             const form = mountWithTheme(
                 <SearchArea
                     onSubmit={onSubmit}
@@ -120,6 +124,9 @@ describe("SearchArea", () => {
             const searchOffers = jest.fn();
             const onSubmit = jest.fn();
             const addSnackbar = () => {};
+
+            // Simulate request success
+            fetch.mockResponse(JSON.stringify({ mockData: true }));
 
             const wrapper = mountWithTheme(
                 <SearchArea

--- a/src/components/Review/Applications/ApplicationsReviewWidget.spec.js
+++ b/src/components/Review/Applications/ApplicationsReviewWidget.spec.js
@@ -80,7 +80,6 @@ describe("Application Review Widget", () => {
     it("Should load current application reviews", async () => {
 
         const applications = generateApplications(3);
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () => { // Necessary since the component auto mutates its state when loading the rows
@@ -122,8 +121,6 @@ describe("Application Review Widget", () => {
 
     it("Should change number of rows visible", async () => {
         const applications = generateApplications(25);
-
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         // Necessary to wrap in act() since the component auto-mutates its state when loading the rows
@@ -152,7 +149,6 @@ describe("Application Review Widget", () => {
     it("Should approve an application", async () => {
         const applications = generateApplications(1, "PENDING");
 
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () =>
@@ -186,7 +182,6 @@ describe("Application Review Widget", () => {
     it("Should maintain state filter after approving an application", async () => {
         const applications = generateApplications(1, "PENDING");
 
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () =>
@@ -234,7 +229,6 @@ describe("Application Review Widget", () => {
     it("Should reject an application", async () => {
         const applications = generateApplications(1, "PENDING");
 
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () =>
@@ -275,7 +269,6 @@ describe("Application Review Widget", () => {
     it("Should maintain state filter after rejecting an application", async () => {
         const applications = generateApplications(1, "PENDING");
 
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () =>
@@ -327,7 +320,6 @@ describe("Application Review Widget", () => {
     it("Should not allow rejecting with invalid reject reason", async () => {
         const applications = generateApplications(1, "PENDING");
 
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () =>
@@ -351,7 +343,6 @@ describe("Application Review Widget", () => {
     it("Should select application review", async () => {
         const applications = generateApplications(2);
 
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () =>
@@ -385,7 +376,6 @@ describe("Application Review Widget", () => {
     it("Should select all application reviews", async () => {
         const applications = generateApplications(2);
 
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () =>
@@ -412,7 +402,6 @@ describe("Application Review Widget", () => {
     it("Should dismiss selection on page change", async () => {
         const applications = generateApplications(6);
 
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () =>
@@ -437,7 +426,6 @@ describe("Application Review Widget", () => {
     it("Should default sort by company name asc and sort rows by company name on click", async () => {
         const applications = generateApplications(10);
 
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () =>
@@ -470,7 +458,6 @@ describe("Application Review Widget", () => {
     it("Should sort rows by requestedAt", async () => {
         const applications = generateApplications(10);
 
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () =>
@@ -505,7 +492,6 @@ describe("Application Review Widget", () => {
     it("Should sort rows by state", async () => {
         const applications = generateApplications(10);
 
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () =>
@@ -540,7 +526,6 @@ describe("Application Review Widget", () => {
     it("Should filter by company name", async () => {
         const applications = generateApplications(11);
 
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () =>
@@ -566,7 +551,6 @@ describe("Application Review Widget", () => {
     it("Should filter by state", async () => {
         const applications = generateApplications(5);
 
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () =>
@@ -613,7 +597,6 @@ describe("Application Review Widget", () => {
     it("Should filter by date", async () => {
         const applications = generateApplications(5);
 
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () =>
@@ -654,7 +637,6 @@ describe("Application Review Widget", () => {
     it("Should reset filters", async () => {
         const applications = generateApplications(5);
 
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications }));
 
         await act(async () =>

--- a/src/pages/HomePage.spec.js
+++ b/src/pages/HomePage.spec.js
@@ -52,6 +52,9 @@ describe("HomePage", () => {
     describe("interaction", () => {
         it("should render search results after search submission", () => {
 
+            // Simulate search request success
+            fetch.mockResponse(JSON.stringify({ mockData: true }));
+
             const wrapper = mountWithStore(
                 <Router>
                     <HomePage/>

--- a/src/services/applicationsReviewService.spec.js
+++ b/src/services/applicationsReviewService.spec.js
@@ -12,7 +12,6 @@ describe("Company Application Service", () => {
     it("should GET the API with the correct filters data", async () => {
 
         // Simulate request success
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ applications: [{ thisIsAnApplication: true }, { thisIsAnotherApplication: true }] }));
 
         const filters = {
@@ -38,7 +37,6 @@ describe("Company Application Service", () => {
     it("should handle network error", async () => {
 
         // Simulate network failure
-        fetchMock.doMock();
         fetch.mockAbort();
 
         try {
@@ -66,7 +64,6 @@ describe("Company Application Service", () => {
         const errors = [{ msg: "error1" }, { msg: "error2" }];
 
         // Simulate request error
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ errors }), { status: 422 });
 
         try {
@@ -92,7 +89,6 @@ describe("Company Application Service", () => {
     it("should POST the API to approve application", async () => {
 
         // Simulate request success
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ mockData: true }));
 
         await approveApplication("id1");
@@ -107,7 +103,6 @@ describe("Company Application Service", () => {
     it("should POST the API to reject application", async () => {
 
         // Simulate request success
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ mockData: true }));
 
         await rejectApplication("id1", "rejectReason");

--- a/src/services/auth.spec.js
+++ b/src/services/auth.spec.js
@@ -6,7 +6,6 @@ import { login, logout } from "./auth";
 describe("Auth Service", () => {
     it("Should send a POST request to authenticate the current session", async () => {
         // Simulate request success
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ mockData: true }));
 
         const email = "email@test.com";
@@ -28,7 +27,6 @@ describe("Auth Service", () => {
     });
 
     it("Should return status code if not 200", async () => {
-        fetchMock.doMock();
         fetch.mockResponse("", { status: 401 });
 
         const email = "email@test.com";
@@ -39,7 +37,6 @@ describe("Auth Service", () => {
 
     it("Should send a DELETE request to log out the current session", async () => {
         // Simulate request success
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ mockData: true }));
 
         await logout();

--- a/src/services/companyApplicationService.spec.js
+++ b/src/services/companyApplicationService.spec.js
@@ -12,7 +12,6 @@ describe("Company Application Service", () => {
     it("should POST the API with the form data in JSON format and dispatch the correct actions", async () => {
 
         // Simulate request success
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ mockData: true }));
 
         const dispatchMock = jest.fn();
@@ -38,7 +37,6 @@ describe("Company Application Service", () => {
     it("should handle network error", async () => {
 
         // Simulate network failure
-        fetchMock.doMock();
         fetch.mockAbort();
 
         const dispatchMock = jest.fn();
@@ -58,7 +56,6 @@ describe("Company Application Service", () => {
         const errors = [{ msg: "error1" }, { msg: "error2" }];
 
         // Simulate request error
-        fetchMock.doMock();
         fetch.mockResponse(JSON.stringify({ errors }), { status: 422 });
 
         const dispatchMock = jest.fn();


### PR DESCRIPTION
Tests were failing inconsistently, which I found to be related to `fetch` calls "leaking" to the real fetch and some requests actually being made. To solve this, I enabled the auto mocking of `fetch` in every test, on the test setup.

Hopefully, this solves all problems, but I am not really sure what was causing them for sure. However, this definitely helped, since they have been passing locally in a consistent manner.