### PR TITLE
Fix useSession reset function to actually reset session data

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 HOST_PORT=3000
 # PUBLIC_URL=https://ni.fe.up.pt/st4g1ng/nijobs/
 # REACT_APP_BASE_ROUTE=test/test123
-REACT_APP_API_HOSTNAME="http://localhost:8087"
+REACT_APP_API_HOSTNAME="https://localhost:8087"
 
 # Uncomment to disable devtools
 # REACT_APP_ALLOW_DEV_TOOLS=false

--- a/README.md
+++ b/README.md
@@ -62,22 +62,24 @@ For it to work, you must serve a backend through some server accessible on the i
 After starting your server on localhost, you can create a tunnel from that localhost server to the internet with ngrok with the following command:
 
 ```bash
-ngrok http <backend port, usually 8087>
+ngrok http https://localhost:8087 --region eu # chage port if not using default 8087
 ```
 
 That will give you two hosts, one for `http`, another for `https`. Use the `https` one in the NIJobs Devtools.
 
-Remember that the backend server must allow the host making the requests (the Netlify origin (i.e. `https://deploy-preview-66--nijobs.netlify.app/`), or your localhost (i.e. `http://localhost:3000`), depending on the use-case).
+Remember that the backend server must allow the host making the requests (the Netlify origin (i.e. `https://deploy-preview-66--nijobs.netlify.app/`), or your localhost (i.e. `https://localhost:3000`), depending on the use-case).
+
+Also, since the development backend uses a self-signed certificate, your browser might block it by default. To fix this, simply visit an endpoint and allow it (e.g. https://localhost:8087).
 
 This can also be useful if you don't want to run the server on your local machine, since you are only developing the frontend. In that case, you can use the staging deployment at `https:/ni.fe.up.pt/st4g1ng/nijobs/api`, but beware that CORS will block your localhost by default, so you must talk with a project maintainer to discuss permissions.
 
 > A `dev.sh` file is available in the project's root folder to run these commands on linux environments (simply run `./dev.sh [--build]`)
 
-This will create a development server with hot reloading which will listen on `http://localhost:<HOST_PORT>`.
+This will create a development server with hot reloading which will listen on `https://localhost:<HOST_PORT>`.
 
 ### Env File Specification
 
-- `HOST_PORT`= The port where you will access the dev server in your machine (`http://localhost:<HOST_PORT>`)
+- `HOST_PORT`= The port where you will access the dev server in your machine (`https://localhost:<HOST_PORT>`)
 
 ## Project Details
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "10.17.0"
   },
   "scripts": {
-    "start": "node scripts/start.js",
+    "start": "HTTPS=true node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "jest --coverage --verbose",
     "test-ci": "jest --coverage --verbose",

--- a/src/components/Navbar/UserMenu.js
+++ b/src/components/Navbar/UserMenu.js
@@ -214,12 +214,12 @@ MobileUserMenu.propTypes = {
     handleLogout: PropTypes.func.isRequired,
 };
 
-const UserMenu = ({ open, anchorRef, sessionData, resetSession, handleClose }) => {
+const UserMenu = ({ open, anchorRef, sessionData, closeSession, handleClose }) => {
 
     const handleLogout = (e) => {
         e.preventDefault();
         handleClose(e);
-        logout().then(() => resetSession());
+        logout().then(() => closeSession());
     };
 
     const isMobile = useMobile();
@@ -254,7 +254,7 @@ UserMenu.propTypes = {
         email: PropTypes.string,
         isAdmin: PropTypes.bool,
     }),
-    resetSession: PropTypes.func.isRequired,
+    closeSession: PropTypes.func.isRequired,
     handleClose: PropTypes.func.isRequired,
 };
 

--- a/src/components/Navbar/UserMenu.spec.js
+++ b/src/components/Navbar/UserMenu.spec.js
@@ -86,7 +86,7 @@ describe("Navbar - LoginForm", () => {
             // Ensure that it does log out, without actually calling API
             logout.mockImplementationOnce(() => Promise.resolve(true));
 
-            const resetSession = jest.fn();
+            const closeSession = jest.fn();
             const handleClose = jest.fn();
             const mockAnchor = { current: <div /> };
             const wrapper = renderWithTheme(
@@ -95,7 +95,7 @@ describe("Navbar - LoginForm", () => {
                         open
                         anchorRef={mockAnchor}
                         sessionData={{ email: "test-email" }}
-                        resetSession={resetSession}
+                        closeSession={closeSession}
                         handleClose={handleClose}
                     />
                 </BrowserRouter>,
@@ -107,7 +107,7 @@ describe("Navbar - LoginForm", () => {
             });
 
             expect(logout).toHaveBeenCalledTimes(1);
-            expect(resetSession).toHaveBeenCalledTimes(1);
+            expect(closeSession).toHaveBeenCalledTimes(1);
             expect(handleClose).toHaveBeenCalledTimes(1);
         });
     });

--- a/src/components/Navbar/index.js
+++ b/src/components/Navbar/index.js
@@ -94,7 +94,9 @@ const Navbar = ({ showLoginModal, toggleLoginModal, showHomePageLink = true, for
                     anchorRef={anchorRef}
                     handleClose={handleUserMenuClose}
                     sessionData={sessionData}
-                    resetSession={resetSession}
+                    closeSession={() => {
+                        resetSession().then(() => updateSessionInfo());
+                    }}
                 />
                 <LoginForm
                     open={showLoginModal}

--- a/src/components/Navbar/index.spec.js
+++ b/src/components/Navbar/index.spec.js
@@ -73,7 +73,12 @@ describe("Navbar", () => {
 
         it("Should hide user menu when logged out ", async () => {
 
-            useSession.mockImplementation(() => ({ isLoggedIn: true, reset: () => {}, revalidate: () => {}, data: { email: "email" } }));
+            useSession.mockImplementation(() => ({
+                isLoggedIn: true,
+                reset: () => Promise.resolve(),
+                revalidate: () => {},
+                data: { email: "email" },
+            }));
 
             const store = createStore(reducer, {}, compose(applyMiddleware(thunk)));
 

--- a/src/hooks/useSession.js
+++ b/src/hooks/useSession.js
@@ -1,4 +1,4 @@
-import useSWR, { mutate } from "swr";
+import useSWR from "swr";
 
 import config from "../config";
 const { API_HOSTNAME } = config;
@@ -23,7 +23,7 @@ export default (options) => {
         }
     };
 
-    const { data, error, isValidating } = useSWR(`${API_HOSTNAME}/auth/me`, getSession, {
+    const { data, error, isValidating, mutate } = useSWR(`${API_HOSTNAME}/auth/me`, getSession, {
         revalidateOnFocus: false,
         initialData: null,
         errorRetryCount: errorRetryCount || DEFAULT_RETRY_COUNT,
@@ -34,8 +34,8 @@ export default (options) => {
         data,
         error,
         isValidating,
-        reset: () => mutate(null),
-        revalidate: () => mutate(`${API_HOSTNAME}/auth/me`),
+        reset: () => mutate(null, false),
+        revalidate: () => mutate(),
         isLoggedIn: !!data || false,
     };
 


### PR DESCRIPTION
Closes #76 

The `mutate` calls were not correctly defined, since they were relying on the bound version (currently implemented in this PR), but they were using the general version (imported from swr directly). Now it should be working as expected, as you can verify, by using your own backend and set it in the devtools in netlify preview.