### PR TITLE
Allow promises from services to be cancellable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6255,6 +6255,11 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
+    "cancelable-promise": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/cancelable-promise/-/cancelable-promise-3.2.3.tgz",
+      "integrity": "sha512-P0yW/pq7ZEx4znOnDd4PqA5l+I/INpo32BE4Rg3QQxVBhKk7g9hAbmJt7oYbffo1q8j+1QfSZHGmjHMqj8RoJw=="
+    },
     "caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tiptap/extension-underline": "^2.0.0-beta.16",
     "@tiptap/react": "^2.0.0-beta.55",
     "@tiptap/starter-kit": "^2.0.0-beta.89",
+    "cancelable-promise": "^3.2.3",
     "clsx": "^1.1.1",
     "date-fns": "^2.16.1",
     "dotenv": "6.2.0",

--- a/src/components/HomePage/SearchArea/SearchArea.js
+++ b/src/components/HomePage/SearchArea/SearchArea.js
@@ -51,15 +51,7 @@ export const AdvancedSearchController = ({
     });
 
     const submitForm = useCallback((e) => {
-        // mind the jobType value when passing value to api,
-        // because for simple search, the initial jobType value will be undefined,
-        // and should be treated as a filter, not a required field, just like jobDuration
         if (e) e.preventDefault();
-
-        // console.log("SEARCH SUBMITTED:");
-        // console.log(searchValue, jobMinDuration, jobMaxDuration, jobType, fields);
-
-        // TODO: Tinker filters later
         searchOffers({ value: searchValue, jobMinDuration, jobMaxDuration, jobType, fields, technologies });
 
         if (onSubmit) onSubmit();

--- a/src/components/Review/Applications/ApplicationsReviewWidget.js
+++ b/src/components/Review/Applications/ApplicationsReviewWidget.js
@@ -15,7 +15,6 @@ import { RowActions } from "./Actions";
 import { searchApplications } from "../../../services/applicationsReviewService";
 import { format, parseISO } from "date-fns";
 import PropTypes from "prop-types";
-import { cancelablePromise } from "../../../utils";
 
 const sorters = {
     name: alphabeticalSorter,

--- a/src/components/Review/Applications/ApplicationsReviewWidget.js
+++ b/src/components/Review/Applications/ApplicationsReviewWidget.js
@@ -57,13 +57,12 @@ const generateRow = ({ companyName, submittedAt, state, rejectReason, motivation
 });
 
 const ApplicationsReviewWidget = () => {
-    // const _amMounted = useRef(); // Prevents setState calls from happening after unmount
     const [rows, setRows] = useState({});
     const [error, setError] = useState(null);
 
     useEffect(() => {
 
-        const promise = cancelablePromise(searchApplications())
+        const request = searchApplications()
             .then((rows) => {
                 const fetchedRows = rows.applications.reduce((rows, row) => {
                     rows[row.id] = generateRow(row);
@@ -75,7 +74,7 @@ const ApplicationsReviewWidget = () => {
                 setError("UnexpectedError");
             });
         return () => {
-            promise.cancel();
+            request.cancel();
         };
     }, []);
 

--- a/src/components/Review/Applications/ApplicationsReviewWidget.spec.js
+++ b/src/components/Review/Applications/ApplicationsReviewWidget.spec.js
@@ -706,4 +706,31 @@ describe("Application Review Widget", () => {
             .map((el) => el.querySelector("td:nth-child(2)").textContent)
         ).toStrictEqual(applications.map((a) => a.companyName));
     });
+
+    it("Should cancel request if unmounted", async () => {
+
+        const abortMock = jest.fn();
+        const realAbortController = global.AbortController;
+        global.AbortController = class {
+            signal = "test-signal"
+            abort = abortMock
+        };
+
+        let unmountFn;
+        await act(async () => {
+            const { unmount } = renderWithStoreAndTheme(
+                <MuiPickersUtilsProvider utils={DateFnsUtils}>
+                    <SnackbarProvider maxSnack={3}>
+                        <Notifier />
+                        <ApplicationsReviewWidget />
+                    </SnackbarProvider>
+                </MuiPickersUtilsProvider>, { initialState: {}, theme });
+            unmountFn = unmount;
+        });
+
+        unmountFn();
+        expect(abortMock).toHaveBeenCalledTimes(1);
+
+        global.AbortController = realAbortController;
+    });
 });

--- a/src/services/applicationsReviewService.js
+++ b/src/services/applicationsReviewService.js
@@ -1,4 +1,5 @@
 import config from "../config";
+import { buildCancelableRequest } from "../utils";
 const { API_HOSTNAME } = config;
 
 
@@ -19,7 +20,7 @@ const encodeFilters = (filters) => {
     return encodedValues.join("&");
 };
 
-export const searchApplications = async (filters, { signal } = {}) => {
+export const searchApplications = buildCancelableRequest(async (filters, { signal } = {}) => {
 
     try {
         const res = await fetch(`${API_HOSTNAME}/applications/company/search${filters ? `?${encodeFilters(filters)}` : ""}`, {
@@ -40,14 +41,15 @@ export const searchApplications = async (filters, { signal } = {}) => {
         if (Array.isArray(error)) throw error;
         throw [{ msg: "Unexpected Error. Please try again later." }];
     }
-};
+});
 
-export const approveApplication = async (applicationId) => {
+export const approveApplication = buildCancelableRequest(async (applicationId, { signal }) => {
 
     try {
         const res = await fetch(`${API_HOSTNAME}/applications/company/${applicationId}/approve`, {
             method: "POST",
             credentials: "include",
+            signal,
         });
         const json = await res.json();
 
@@ -62,9 +64,9 @@ export const approveApplication = async (applicationId) => {
         if (Array.isArray(error)) throw error;
         throw [{ msg: "Unexpected Error. Please try again later." }];
     }
-};
+});
 
-export const rejectApplication = async (applicationId, rejectReason) => {
+export const rejectApplication = buildCancelableRequest(async (applicationId, rejectReason, { signal }) => {
     try {
         const res = await fetch(`${API_HOSTNAME}/applications/company/${applicationId}/reject`, {
             method: "POST",
@@ -73,6 +75,7 @@ export const rejectApplication = async (applicationId, rejectReason) => {
                 "Content-Type": "application/json",
             },
             body: JSON.stringify({ rejectReason }),
+            signal,
         });
         const json = await res.json();
 
@@ -87,4 +90,4 @@ export const rejectApplication = async (applicationId, rejectReason) => {
         if (Array.isArray(error)) throw error;
         throw [{ msg: "Unexpected Error. Please try again later." }];
     }
-};
+});

--- a/src/services/applicationsReviewService.js
+++ b/src/services/applicationsReviewService.js
@@ -19,12 +19,13 @@ const encodeFilters = (filters) => {
     return encodedValues.join("&");
 };
 
-export const searchApplications = async (filters) => {
+export const searchApplications = async (filters, { signal } = {}) => {
 
     try {
         const res = await fetch(`${API_HOSTNAME}/applications/company/search${filters ? `?${encodeFilters(filters)}` : ""}`, {
             method: "GET",
             credentials: "include",
+            signal,
         });
         const json = await res.json();
 

--- a/src/services/applicationsReviewService.spec.js
+++ b/src/services/applicationsReviewService.spec.js
@@ -27,10 +27,10 @@ describe("Company Application Service", () => {
         await searchApplications(filters);
 
         const filtersString = "limit=10&offset=10&companyName=company&state=[\"APPROVED\",\"PENDING\"]&sortBy=state:asc,companyName:desc";
-        expect(fetch).toHaveBeenCalledWith(`${API_HOSTNAME}/applications/company/search?${filtersString}`, {
+        expect(fetch).toHaveBeenCalledWith(`${API_HOSTNAME}/applications/company/search?${filtersString}`, expect.objectContaining({
             method: "GET",
             credentials: "include",
-        });
+        }));
 
     });
 
@@ -93,10 +93,10 @@ describe("Company Application Service", () => {
 
         await approveApplication("id1");
 
-        expect(fetch).toHaveBeenCalledWith(`${API_HOSTNAME}/applications/company/id1/approve`, {
+        expect(fetch).toHaveBeenCalledWith(`${API_HOSTNAME}/applications/company/id1/approve`, expect.objectContaining({
             method: "POST",
             credentials: "include",
-        });
+        }));
 
     });
 
@@ -107,14 +107,14 @@ describe("Company Application Service", () => {
 
         await rejectApplication("id1", "rejectReason");
 
-        expect(fetch).toHaveBeenCalledWith(`${API_HOSTNAME}/applications/company/id1/reject`, {
+        expect(fetch).toHaveBeenCalledWith(`${API_HOSTNAME}/applications/company/id1/reject`, expect.objectContaining({
             method: "POST",
             credentials: "include",
             headers: {
                 "Content-Type": "application/json",
             },
             body: JSON.stringify({ rejectReason: "rejectReason" }),
-        });
+        }));
 
     });
 });

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,9 +1,10 @@
 import config from "../config";
+import { buildCancelableRequest } from "../utils";
 const { API_HOSTNAME } = config;
 
 const AUTH_ENDPOINT = `${API_HOSTNAME}/auth/login`;
 
-export const login = async (email, password) => {
+export const login = buildCancelableRequest(async (email, password, { signal }) => {
 
     const res = await fetch(AUTH_ENDPOINT, {
         method: "POST",
@@ -12,14 +13,16 @@ export const login = async (email, password) => {
             "Content-Type": "application/json",
         },
         body: JSON.stringify({ email, password }),
+        signal,
     });
 
     if (!res.ok) throw { status: res.status };
 
+});
 
-};
-export const logout = () =>
+export const logout = buildCancelableRequest(({ signal }) =>
     fetch(AUTH_ENDPOINT, {
         method: "DELETE",
         credentials: "include",
-    });
+        signal,
+    }));

--- a/src/services/auth.spec.js
+++ b/src/services/auth.spec.js
@@ -13,7 +13,7 @@ describe("Auth Service", () => {
 
         await login(email, password);
 
-        expect(fetch).toHaveBeenCalledWith(`${API_HOSTNAME}/auth/login`, {
+        expect(fetch).toHaveBeenCalledWith(`${API_HOSTNAME}/auth/login`, expect.objectContaining({
             method: "POST",
             credentials: "include",
             headers: {
@@ -23,7 +23,7 @@ describe("Auth Service", () => {
                 email,
                 password,
             }),
-        });
+        }));
     });
 
     it("Should return status code if not 200", async () => {
@@ -41,9 +41,9 @@ describe("Auth Service", () => {
 
         await logout();
 
-        expect(fetch).toHaveBeenCalledWith(`${API_HOSTNAME}/auth/login`, {
+        expect(fetch).toHaveBeenCalledWith(`${API_HOSTNAME}/auth/login`, expect.objectContaining({
             method: "DELETE",
             credentials: "include",
-        });
+        }));
     });
 });

--- a/src/services/companyApplicationService.js
+++ b/src/services/companyApplicationService.js
@@ -5,9 +5,10 @@ import {
 } from "../actions/companyApplicationActions";
 
 import config from "../config";
+import { buildCancelableRequest } from "../utils";
 const { API_HOSTNAME } = config;
 
-export const submitCompanyApplication = (formData) => async (dispatch) => {
+export const submitCompanyApplication = (formData) => buildCancelableRequest(async (dispatch, { signal }) => {
     dispatch(setCompanyApplicationSending(true));
     dispatch(setCompanyApplicationSubmissionError([]));
 
@@ -18,6 +19,7 @@ export const submitCompanyApplication = (formData) => async (dispatch) => {
                 "Content-Type": "application/json",
             },
             body: JSON.stringify(formData),
+            signal,
         });
         const json = await res.json();
 
@@ -41,4 +43,4 @@ export const submitCompanyApplication = (formData) => async (dispatch) => {
         return false;
     }
 
-};
+});

--- a/src/services/companyApplicationService.spec.js
+++ b/src/services/companyApplicationService.spec.js
@@ -19,13 +19,13 @@ describe("Company Application Service", () => {
         const formData = { field1: 1, field2: 2 };
         await submitCompanyApplication(formData)(dispatchMock);
 
-        expect(fetch).toHaveBeenCalledWith(`${API_HOSTNAME}/apply/company`, {
+        expect(fetch).toHaveBeenCalledWith(`${API_HOSTNAME}/apply/company`, expect.objectContaining({
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
             },
             body: JSON.stringify(formData),
-        });
+        }));
 
 
         expect(dispatchMock).toHaveBeenNthCalledWith(1, setCompanyApplicationSending(true));

--- a/src/services/offerService.js
+++ b/src/services/offerService.js
@@ -1,12 +1,13 @@
 import { setLoadingOffers, setSearchOffers, setOffersFetchError, resetOffersFetchError } from "../actions/searchOffersActions";
 import Offer from "../components/HomePage/SearchResultsArea/Offer/Offer";
 import config from "../config";
-import { parseFiltersToURL } from "../utils";
+import { parseFiltersToURL, buildCancelableRequest } from "../utils";
+
 
 const { API_HOSTNAME } = config;
 
 
-export const searchOffers = (filters) => async (dispatch) => {
+export const searchOffers = (filters) => buildCancelableRequest(async (dispatch, { signal }) => {
 
     dispatch(resetOffersFetchError());
     dispatch(setLoadingOffers(true));
@@ -15,6 +16,7 @@ export const searchOffers = (filters) => async (dispatch) => {
         const res = await fetch(`${API_HOSTNAME}/offers?${parseFiltersToURL(filters)}`, {
             method: "GET",
             credentials: "include",
+            signal,
         });
         if (!res.ok) {
             dispatch(setOffersFetchError({
@@ -39,7 +41,7 @@ export const searchOffers = (filters) => async (dispatch) => {
         dispatch(setLoadingOffers(false));
         // TODO count metrics
     }
-};
+});
 
 export const hideOffer = async (offerId) => {
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -323,4 +323,19 @@ export const cancelablePromise = (promise, onCancelCallback) => new CancelablePr
     promise.then(resolve, reject);
 });
 
+export const buildCancelablePromise = (promiseFn, onCancelCallback) => (...args) => new CancelablePromise((resolve, reject, onCancel) => {
+    if (onCancelCallback) onCancel(onCancelCallback);
+
+    promiseFn(...args).then(resolve, reject);
+});
+
+export const buildCancelableRequest = (promiseFn) => (...args) => new CancelablePromise((resolve, reject, onCancel) => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    onCancel(() => controller.abort());
+
+    promiseFn(...args, { signal }).then(resolve, reject);
+});
+
 export { default as UndoableActionsHandlerProvider, UndoableActions } from "./UndoableActionsHandlerProvider";

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,6 +6,7 @@ import useSession from "../hooks/useSession";
 import { addSnackbar } from "../actions/notificationActions";
 import { connect } from "react-redux";
 import useComponentController from "../hooks/useComponentController";
+import CancelablePromise from "cancelable-promise";
 
 export const smoothScrollToRef = (ref) => {
 
@@ -315,5 +316,11 @@ ProtectedRoute.propTypes = {
     controller: PropTypes.func,
     controllerProps: PropTypes.object,
 };
+
+export const cancelablePromise = (promise, onCancelCallback) => new CancelablePromise((resolve, reject, onCancel) => {
+    if (onCancelCallback) onCancel(onCancelCallback);
+
+    promise.then(resolve, reject);
+});
 
 export { default as UndoableActionsHandlerProvider, UndoableActions } from "./UndoableActionsHandlerProvider";


### PR DESCRIPTION
This PR will allow async work done by services to be cancelable from React components (mostly useful when unmounting components, in order to cancel any work on unmounted components)

Additionally, since we are using fetch, we can actually cancel the requests with the AbortableController API (https://developer.mozilla.org/en-US/docs/Web/API/AbortController) - This would be done on the `onCancel` callback of the promises.