### PR TITLE
fix: 💄 broken login and join us buttons

### DIFF
--- a/src/components/HomePage/ProductPlacementArea/productDescriptionStyles.js
+++ b/src/components/HomePage/ProductPlacementArea/productDescriptionStyles.js
@@ -6,7 +6,6 @@ export default ({ isMobile }) => makeStyles((theme) => ({
         display: "flex",
         justifyContent: "center",
         width: isMobile ? "100%" : "80%",
-        height: !isMobile && "50vh",
         margin: "5em auto 10em",
         textAlign: "center",
     },


### PR DESCRIPTION
Fixes #144.

On mobile, these two buttons overlap the page footer.
This is because there are stylings that set the product placement area's height to 50vh, therefore, when it exceeds that height, the elements overlap.