### PR TITLE
Search Analytics

### DIFF
--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@ REACT_APP_API_HOSTNAME="https://localhost:8087"
 # REACT_APP_ALLOW_DEV_TOOLS=false
 
 # Google Analytics' Universal ID
-ANALYTICS_ID="UA-208192118-1"
+ANALYTICS_ID=
 
 # GeoLocation Rapid Api key
 GEO_API_KEY="APIKEY"

--- a/src/services/offerService.js
+++ b/src/services/offerService.js
@@ -2,7 +2,7 @@ import { setLoadingOffers, setSearchOffers, setOffersFetchError, resetOffersFetc
 import Offer from "../components/HomePage/SearchResultsArea/Offer/Offer";
 import config from "../config";
 import { parseFiltersToURL, buildCancelableRequest } from "../utils";
-import { createEvent, EVENT_TYPES, TIMED_ACTIONS, measureTime } from "../utils/analytics";
+import { createEvent, EVENT_TYPES, TIMED_ACTIONS, measureTime, sendSearchReport } from "../utils/analytics";
 import ErrorTypes from "../utils/ErrorTypes";
 const { API_HOSTNAME } = config;
 
@@ -42,6 +42,7 @@ export const searchOffers = (filters) => buildCancelableRequest(
             dispatch(setSearchOffers(offers.map((offerData) => new Offer(offerData))));
             dispatch(setLoadingOffers(false));
 
+            sendSearchReport(filters, `/offers?${query}`);
             createEvent(EVENT_TYPES.SUCCESS(OFFER_SEARCH_METRIC_ID, query));
 
         } catch (error) {

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -61,6 +61,20 @@ export const createEvent = (event = EVENT_TYPES.OTHER) => {
  * @param {*} queryUrl URL to be used for the pageview
  */
 export const sendSearchReport = (filters, queryUrl) => {
+    const searchDimensions = parseFiltersToDimensions(filters);
+    const parsedUrl = parseSearchUrl(queryUrl);
+
+    ReactGa.set(searchDimensions);
+    ReactGa.pageview(parsedUrl);
+};
+
+/**
+ * Parses search filters to GA dimensions. Joins arrays by commas
+ *
+ * @param {*} filters Original search filters
+ * @returns Parsed search filters
+ */
+export const parseFiltersToDimensions = (filters) => {
     const searchDimensions = {};
 
     Object.keys(filters)
@@ -73,15 +87,24 @@ export const sendSearchReport = (filters, queryUrl) => {
                 filters[key];
         });
 
-    // Needed to register searches without value
+    return searchDimensions;
+};
+
+/**
+ * Parses search URL to register searches without value
+ */
+export const parseSearchUrl = (queryUrl) => {
+    if (queryUrl.includes(QUERY_VALUE_PARAMETER)) return queryUrl;
+
     let parsedUrl = queryUrl;
-    if (!parsedUrl.includes(QUERY_VALUE_PARAMETER)) {
-        if (parsedUrl.slice(-1) !== "?") parsedUrl += "&";
-        parsedUrl += `${QUERY_VALUE_PARAMETER}[EMPTY]`;
+    if (queryUrl.includes("?")) {
+        if (queryUrl.slice(-1) !== "?") parsedUrl += "&";
+    } else {
+        parsedUrl += "?";
     }
 
-    ReactGa.set(searchDimensions);
-    ReactGa.pageview(parsedUrl);
+    parsedUrl += `${QUERY_VALUE_PARAMETER}[EMPTY]`;
+    return parsedUrl;
 };
 
 export const EVENT_TYPES = Object.freeze({
@@ -160,7 +183,7 @@ export const TIMED_ACTIONS = Object.freeze({
 /**
  * Object mapping search filters to GA dimensions' indexes
  */
-const DIMENSION_IDS = Object.freeze({
+export const DIMENSION_IDS = Object.freeze({
     jobType: "dimension1",
     jobMinDuration: "dimension2",
     jobMaxDuration: "dimension3",

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -1,4 +1,5 @@
 import ReactGa from "react-ga";
+const QUERY_VALUE_PARAMETER = "value=";
 
 /**
  * Initializes Google Analytics.
@@ -50,6 +51,37 @@ export const recordTime = (action = TIMED_ACTIONS.UNKNOWN, t0, t1, label) => {
  */
 export const createEvent = (event = EVENT_TYPES.OTHER) => {
     ReactGa.event(event);
+};
+
+/**
+ * Sends a search report to Google Analytics.
+ * Filters are recorded using custom dimensions, except for value which is the main parameter.
+ *
+ * @param {*} filters Object with the search filters
+ * @param {*} queryUrl URL to be used for the pageview
+ */
+export const sendSearchReport = (filters, queryUrl) => {
+    const searchDimensions = {};
+
+    Object.keys(filters)
+        .filter((key) => Array.isArray(filters[key]) ? filters[key].length : !!filters[key] // Remove falsy values
+            && DIMENSION_IDS[key]) // Check if filter should be recorded
+        .forEach((key) => {
+            searchDimensions[DIMENSION_IDS[key]] = Array.isArray(filters[key]) ?
+                filters[key].join()
+                :
+                filters[key];
+        });
+
+    // Needed to register searches without value
+    let parsedUrl = queryUrl;
+    if (!parsedUrl.includes(QUERY_VALUE_PARAMETER)) {
+        if (parsedUrl.slice(-1) !== "?") parsedUrl += "&";
+        parsedUrl += `${QUERY_VALUE_PARAMETER}[EMPTY]`;
+    }
+
+    ReactGa.set(searchDimensions);
+    ReactGa.pageview(parsedUrl);
 };
 
 export const EVENT_TYPES = Object.freeze({
@@ -123,4 +155,15 @@ export const TIMED_ACTIONS = Object.freeze({
         category: "unknown",
         variable: "unknown",
     },
+});
+
+/**
+ * Object mapping search filters to GA dimensions' indexes
+ */
+const DIMENSION_IDS = Object.freeze({
+    jobType: "dimension1",
+    jobMinDuration: "dimension2",
+    jobMaxDuration: "dimension3",
+    fields: "dimension4",
+    technologies: "dimension5",
 });

--- a/src/utils/analytics.spec.js
+++ b/src/utils/analytics.spec.js
@@ -1,0 +1,90 @@
+import { parseFiltersToDimensions, parseSearchUrl, DIMENSION_IDS } from "./analytics";
+
+describe("analytics", () => {
+    describe("parse search filters to dimensions", () => {
+        const jobTypeId = DIMENSION_IDS.jobType;
+        const jobMinDurationId = DIMENSION_IDS.jobMinDuration;
+        const technologiesId = DIMENSION_IDS.technologies;
+
+        it("should include tracked search filters", () => {
+            const filters = {
+                jobType: "FULL-TIME",
+                jobMinDuration: 10,
+                technologies: ["React", "Vue"],
+            };
+            const searchDimensions = parseFiltersToDimensions(filters);
+
+            expect(searchDimensions).toHaveProperty(jobTypeId);
+            expect(searchDimensions[jobTypeId]).toBe(filters.jobType);
+            expect(searchDimensions).toHaveProperty(jobMinDurationId);
+            expect(searchDimensions[jobMinDurationId]).toBe(filters.jobMinDuration);
+
+            expect(searchDimensions).toHaveProperty(technologiesId);
+            expect(searchDimensions[technologiesId]).toBe("React,Vue");
+        });
+
+        it("should not include untracked search filters", () => {
+            const filters = {
+                jobType: "FULL-TIME",
+                test: "Test",
+            };
+            const searchDimensions = parseFiltersToDimensions(filters);
+
+            expect(searchDimensions).toHaveProperty(jobTypeId);
+            expect(searchDimensions[jobTypeId]).toBe(filters.jobType);
+            expect(Object.keys(searchDimensions).length).toBe(1);
+        });
+
+        it("should not include falsy values", () => {
+            const filters = {
+                jobType: "FULL-TIME",
+                technologies: false,
+            };
+            const searchDimensions = parseFiltersToDimensions(filters);
+
+            expect(searchDimensions).toHaveProperty(jobTypeId);
+            expect(searchDimensions[jobTypeId]).toBe(filters.jobType);
+            expect(Object.keys(searchDimensions).length).toBe(1);
+            expect(searchDimensions).not.toHaveProperty(technologiesId);
+        });
+
+        it("should not include values with empty arrays", () => {
+            const filters = {
+                jobType: "FULL-TIME",
+                technologies: [],
+            };
+            const searchDimensions = parseFiltersToDimensions(filters);
+
+            expect(searchDimensions).toHaveProperty(jobTypeId);
+            expect(searchDimensions[jobTypeId]).toBe(filters.jobType);
+            expect(Object.keys(searchDimensions).length).toBe(1);
+            expect(searchDimensions).not.toHaveProperty(technologiesId);
+        });
+    });
+
+    describe("parse search URL", () => {
+        it("should mantain query when value is included", () => {
+            const queryUrl = "/test?value=test";
+            const parsedUrl = parseSearchUrl(queryUrl);
+            expect(parsedUrl).toEqual(queryUrl);
+        });
+
+        it("should append empty value when it's not in the query", () => {
+            const queryUrl = "/test?jobType=FULL-TIME";
+            const parsedUrl = parseSearchUrl(queryUrl);
+            expect(parsedUrl).toBe(`${queryUrl}&value=[EMPTY]`);
+        });
+
+        it("should append empty value when there is no query", () => {
+            const rawUrl = "/test";
+            const parsedUrl = parseSearchUrl(rawUrl);
+            expect(parsedUrl).toBe(`${rawUrl}?value=[EMPTY]`);
+        });
+
+        it("should append empty value when query is empty", () => {
+            const queryUrl = "/test?";
+            const parsedUrl = parseSearchUrl(queryUrl);
+            expect(parsedUrl).toBe(`${queryUrl}value=[EMPTY]`);
+        });
+    });
+});


### PR DESCRIPTION
Closes #149 

I solved the problems stated in the issue by using [custom dimensions](https://support.google.com/analytics/answer/2709828?hl=en#zippy=%2Cin-this-article). Now, each of our search parameters are specified with one, except for `value`, which is still set up as GA's main search parameter.

In the GA property, your search configuration should look like below (under Admin->View Settings):
![image](https://user-images.githubusercontent.com/55768934/151728136-17350722-323b-46c5-950d-5df88077f724.png)

Additionally, the custom dimensions should look like so. Be aware that the indices must match the ones being used in the code:
![image](https://user-images.githubusercontent.com/55768934/151728193-0ceb3090-0e5d-4c2c-8375-e98c666c5eec.png)

You can also learn more about GA's search analytics [here](https://www.digishuffle.com/blogs/internal-site-search-google-analytics/#sitesearch14_).

This approach has the problem that you can only send one value for a dimension in each page view (i.e. a search event). To overcome this issue and register parameters with multiple values (e.g. technologies), I decided to join them by commas, similarly to what's suggested in this [thread](https://stackoverflow.com/questions/18403334/universal-analytics-push-multiple-values-for-one-dimension-and-one-pageview).

Below, you can find a few examples of how you can analyze the searches made in NIJobs:

#### Main search page
![image](https://user-images.githubusercontent.com/55768934/151728538-e20a55bf-d300-41fb-96e8-53e656fbeab1.png)
Here, we can look at the frequency of searches in the website. Under the graph, we have logs of the full-text searches made, where [EMPTY] means the user didn't use it.

#### Search Terms page, filtered by a custom dimension
![image](https://user-images.githubusercontent.com/55768934/151728701-376dd84b-40d0-4027-b541-0d851829c471.png)
Here, we can see how much a given parameter is being used and also look at the logs of the respective searches.

#### Filtering searches by a dimension value (e.g. Angular)
![image](https://user-images.githubusercontent.com/55768934/151728100-b188be4a-d760-4ebe-b6ad-5623d3c20d8b.png)
We can see how much a specific technology/field is being searched for. It's also possible to combine multiple values with GA's filtering tool. We can also specify searches with **only** Angular and no other technologies

#### Checking which fields are the most popular in a pie char
![image](https://user-images.githubusercontent.com/55768934/151729243-e3066088-adad-4d60-95a2-6b91c37b4e8e.png)
Can be done for other parameters too. However, note that multi-value parameters are tied together:

![image](https://user-images.githubusercontent.com/55768934/151729958-e1a1c031-1d8c-418b-a4e6-8ac8c0a41adf.png)
