### PR TITLE
250 unable to remove optional offer fields

### DIFF
--- a/src/components/HomePage/SearchResultsArea/Offer/OfferDetails.js
+++ b/src/components/HomePage/SearchResultsArea/Offer/OfferDetails.js
@@ -214,7 +214,7 @@ const OfferDetails = ({
                     </Tooltip>
                 </Grid>
                 {
-                    !loading && (offer.vacancies > 0) &&
+                    !loading && offer.vacancies &&
                     (
                         <Grid item xs={12} md={6}>
                             <Tooltip title="Vacancies" placement="left">

--- a/src/components/HomePage/SearchResultsArea/Offer/OfferDetails.js
+++ b/src/components/HomePage/SearchResultsArea/Offer/OfferDetails.js
@@ -214,15 +214,17 @@ const OfferDetails = ({
                     </Tooltip>
                 </Grid>
                 {
-                    !loading && offer.vacancies &&
-                    <Grid item xs={12} md={6}>
-                        <Tooltip title="Vacancies" placement="left">
-                            <Typography display="inline" variant="body1" color="secondary">
-                                <FindInPage className={classes.iconStyle} />
-                                {`${offer.vacancies} ${offer.vacancies === 1 ? "vacancy" : "vacancies"}`}
-                            </Typography>
-                        </Tooltip>
-                    </Grid>
+                    !loading && (offer.vacancies > 0) &&
+                    (
+                        <Grid item xs={12} md={6}>
+                            <Tooltip title="Vacancies" placement="left">
+                                <Typography display="inline" variant="body1" color="secondary">
+                                    <FindInPage className={classes.iconStyle} />
+                                    {`${offer.vacancies} ${offer.vacancies === 1 ? "vacancy" : "vacancies"}`}
+                                </Typography>
+                            </Tooltip>
+                        </Grid>
+                    )
                 }
                 {
                     !loading && (offer.isPaid !== null && offer.isPaid !== undefined) &&

--- a/src/components/Offers/Edit/EditOfferForm.js
+++ b/src/components/Offers/Edit/EditOfferForm.js
@@ -93,7 +93,6 @@ export const EditOfferController = () => {
 
     const handleSubmit = useCallback(
         (data) => {
-            console.log(data);
             setLoading(true);
             const [jobMinDuration, jobMaxDuration] = data.jobDuration;
             const publishDateChanged = data.publishDate.getTime() !== new Date(offer?.publishDate).getTime();

--- a/src/components/Offers/Edit/EditOfferForm.js
+++ b/src/components/Offers/Edit/EditOfferForm.js
@@ -108,7 +108,7 @@ export const EditOfferController = () => {
                 requirements: data.requirements.map((val) => val.value),
                 isPaid: data.isPaid === "none" ? null : data.isPaid,
                 jobStartDate: !data.jobStartDate ? null : data.jobStartDate,
-                applyURL: data.applyURL || undefined,
+                applyURL: data.applyURL || null,
                 jobMinDuration,
                 jobMaxDuration,
             })

--- a/src/components/Offers/Edit/EditOfferForm.js
+++ b/src/components/Offers/Edit/EditOfferForm.js
@@ -100,7 +100,7 @@ export const EditOfferController = () => {
             editOffer({
                 offerId: id,
                 ...data,
-                vacancies: (data.vacancies === "") ? 0 : data.vacancies,
+                vacancies: data.vacancies || null,
                 publishDate: publishDateChanged ? data.publishDate : undefined,
                 publishEndDate: publishEndDateChanged ? data.publishEndDate : undefined,
                 contacts: data.contacts.map((val) => val.value),

--- a/src/components/Offers/Edit/EditOfferForm.js
+++ b/src/components/Offers/Edit/EditOfferForm.js
@@ -93,6 +93,7 @@ export const EditOfferController = () => {
 
     const handleSubmit = useCallback(
         (data) => {
+            console.log(data);
             setLoading(true);
             const [jobMinDuration, jobMaxDuration] = data.jobDuration;
             const publishDateChanged = data.publishDate.getTime() !== new Date(offer?.publishDate).getTime();
@@ -100,13 +101,13 @@ export const EditOfferController = () => {
             editOffer({
                 offerId: id,
                 ...data,
-                vacancies: data.vacancies || undefined,
+                vacancies: (data.vacancies === "") ? 0 : data.vacancies,
                 publishDate: publishDateChanged ? data.publishDate : undefined,
                 publishEndDate: publishEndDateChanged ? data.publishEndDate : undefined,
                 contacts: data.contacts.map((val) => val.value),
                 requirements: data.requirements.map((val) => val.value),
-                isPaid: data.isPaid === "none" ? undefined : data.isPaid,
-                jobStartDate: !data.jobStartDate ? undefined : data.jobStartDate,
+                isPaid: data.isPaid === "none" ? null : data.isPaid,
+                jobStartDate: !data.jobStartDate ? null : data.jobStartDate,
                 applyURL: data.applyURL || undefined,
                 jobMinDuration,
                 jobMaxDuration,

--- a/src/components/Offers/Edit/EditOfferForm.spec.js
+++ b/src/components/Offers/Edit/EditOfferForm.spec.js
@@ -85,6 +85,7 @@ describe("Edit Offer Form", () => {
             "contact1",
             "contact2",
         ],
+        isPaid: null,
         applyURL: "https://www.test.com",
     });
 

--- a/src/components/Offers/Edit/EditOfferSchema.js
+++ b/src/components/Offers/Edit/EditOfferSchema.js
@@ -3,7 +3,7 @@ import { format } from "date-fns";
 import * as yup from "yup";
 import { HumanValidationReasons } from "../../../utils";
 import { generateValidationRule, isValidPublishEndDate } from "../Form/OfferUtils";
-import { validApplyURL } from "../../../utils/offer/OfferUtils";
+import { validApplyURLRegex } from "../../../utils/offer/OfferUtils";
 
 export default yup.object().shape({
     title: yup.string()
@@ -74,5 +74,8 @@ export default yup.object().shape({
     owner: yup.string(),
     applyURL: yup.string()
         .nullable(true)
-        .test("applyURL-regex", HumanValidationReasons.BAD_APPLY_URL, validApplyURL),
+        .matches(validApplyURLRegex, {
+            message: HumanValidationReasons.BAD_APPLY_URL,
+            excludeEmptyString: true,
+        }),
 });

--- a/src/components/Offers/New/CreateOfferSchema.js
+++ b/src/components/Offers/New/CreateOfferSchema.js
@@ -3,7 +3,7 @@ import { format } from "date-fns";
 import * as yup from "yup";
 import { HumanValidationReasons } from "../../../utils";
 import { generateValidationRule, isValidPublishEndDate } from "../Form/OfferUtils";
-import { validApplyURL } from "../../../utils/offer/OfferUtils";
+import { validApplyURLRegex } from "../../../utils/offer/OfferUtils";
 
 export default yup.object().shape({
     title: yup.string()
@@ -75,5 +75,8 @@ export default yup.object().shape({
     owner: yup.string(),
     applyURL: yup.string()
         .nullable(true)
-        .test("applyURL-regex", HumanValidationReasons.BAD_APPLY_URL, validApplyURL),
+        .matches(validApplyURLRegex, {
+            message: HumanValidationReasons.BAD_APPLY_URL,
+            excludeEmptyString: true,
+        }),
 });

--- a/src/utils/offer/OfferUtils.js
+++ b/src/utils/offer/OfferUtils.js
@@ -20,5 +20,5 @@ export const validApplyURL = (val) => {
     const httpRegex = /^https?:\/\/\S+\.\S+$/;
     const emailRegex = /^mailto:(\S+@\S+)$/;
 
-    return httpRegex.test(val) || emailRegex.test(val);
+    return httpRegex.test(val) || emailRegex.test(val) || (val === "");
 };

--- a/src/utils/offer/OfferUtils.js
+++ b/src/utils/offer/OfferUtils.js
@@ -16,9 +16,7 @@ const HumanReadableErrors = Object.freeze({
 
 export const getHumanError = (error) => generalHumanError(error, HumanReadableErrors);
 
-export const validApplyURL = (val) => {
-    const httpRegex = /^https?:\/\/\S+\.\S+$/;
-    const emailRegex = /^mailto:(\S+@\S+)$/;
+export const HTTPRegex = /^https?:\/\/\S+\.\S+$/;
+export const MailRegex = /^mailto:(\S+@\S+)$/;
 
-    return httpRegex.test(val) || emailRegex.test(val) || (val === "") || (val === null);
-};
+export const validApplyURLRegex = new RegExp(`${HTTPRegex.source}|${MailRegex.source}`);

--- a/src/utils/offer/OfferUtils.js
+++ b/src/utils/offer/OfferUtils.js
@@ -20,5 +20,5 @@ export const validApplyURL = (val) => {
     const httpRegex = /^https?:\/\/\S+\.\S+$/;
     const emailRegex = /^mailto:(\S+@\S+)$/;
 
-    return httpRegex.test(val) || emailRegex.test(val) || (val === "");
+    return httpRegex.test(val) || emailRegex.test(val) || (val === "") || (val === null);
 };


### PR DESCRIPTION
Vacancies are done, the default value is 0, but if it has no value it is not shown anyway, whenever the offer is edited again the value is set to null. Like other optional fields I'm in doubt if I should set them as null when creating (on the create form), how they are right now makes them nonexistent in the database on creation.
Also, isPaid and jobStartDate are set to null when proper input is not provided.
About the applyURL, I saw that it is optional on the database, therefore I had to modify the util that ran the regex to ignore the verification if the value was null or an empty string.
Lastly, vacancies had a visual bug where if it's value was 0 there would show a simple text 0 where the vacancies should be, but that was also fixed by checking if there are more than zero vacancies.