### PR TITLE
Fix/nijobs logo mobile landscape

### DIFF
--- a/src/components/HomePage/mainViewStyles.js
+++ b/src/components/HomePage/mainViewStyles.js
@@ -9,8 +9,12 @@ export default makeStyles((theme) => ({
     mainLogo: ({ isMobile }) => ({
         textAlign: "center",
         paddingBottom: "3em",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
         "& img": {
             width: isMobile ? "80%" : "50%",
+            maxHeight: isMobile ? "max(20vh, 6em)" : "unset",
         },
     }),
     mainLogoMobile: {


### PR DESCRIPTION
Closes #161 . Previously, the NIJobs logo occupied 80% of available width in any mobile view. This should change that, leaving the logo in mobile landscape view looking closer to the desktop view. The solution isn't as great as I wanted, as I couldn't figure out a way to variably define the percentage of the page width the logo should take. Feedback is much appreciated.

![image](https://user-images.githubusercontent.com/75331417/201156653-e410e0d4-2a86-4f96-ba60-22b59d24b15a.png)

![image](https://user-images.githubusercontent.com/75331417/201156812-a99494c1-f7c5-40ef-a2e0-49f38cb06e9f.png)


