### PR TITLE
Feature/239 evident see offers wo user parameters

### DIFF
--- a/src/components/HomePage/SearchArea/SearchArea.js
+++ b/src/components/HomePage/SearchArea/SearchArea.js
@@ -177,6 +177,10 @@ export const SearchArea = ({ onSubmit, searchValue,
                 </form>
                 <SubmitSearchButton
                     onClick={submitForm}
+                    searchHasUserInput={
+                        (searchValue !== "" && searchValue !== undefined)
+                        || advancedOptionsActive
+                    }
                 />
             </Paper>
         </ContextProvider>

--- a/src/components/HomePage/SearchArea/SearchArea.spec.js
+++ b/src/components/HomePage/SearchArea/SearchArea.spec.js
@@ -10,10 +10,12 @@ import {
 } from "../../../actions/searchOffersActions";
 import { createTheme } from "@material-ui/core";
 import { renderWithStoreAndTheme, screen, fireEvent, act } from "../../../test-utils";
-
 import { MemoryRouter } from "react-router-dom";
 
+import PropTypes from "prop-types";
+
 import qs from "qs";
+import { INITIAL_JOB_TYPE } from "../../../reducers/searchOffersReducer";
 
 // eslint-disable-next-line react/prop-types
 const RouteWrappedContent = ({ children, url = "/" }) => (
@@ -21,6 +23,47 @@ const RouteWrappedContent = ({ children, url = "/" }) => (
         {children}
     </MemoryRouter>
 );
+
+const SearchAreaWrapper = ({
+    searchValue = "", jobType = INITIAL_JOB_TYPE, jobDuration = [null, null], filterJobDuration = false,
+    showJobDurationSlider = false, fields = [], technologies = [], setShowJobDurationSlider = () => { },
+    setTechs = () => { }, setJobDuration = () => { }, setFields = () => { }, setJobType = () => { },
+    setSearchValue = () => { }, onSubmit = () => {},
+}) => (
+    <SearchArea
+        searchValue={searchValue}
+        jobType={jobType}
+        jobDuration={jobDuration}
+        filterJobDuration={filterJobDuration}
+        fields={fields}
+        technologies={technologies}
+        showJobDurationSlider={showJobDurationSlider}
+        setShowJobDurationSlider={setShowJobDurationSlider}
+        setTechs={setTechs}
+        setJobDuration={setJobDuration}
+        setFields={setFields}
+        setJobType={setJobType}
+        setSearchValue={setSearchValue}
+        onSubmit={onSubmit}
+    />
+);
+
+SearchAreaWrapper.propTypes = {
+    onSubmit: PropTypes.func,
+    searchValue: PropTypes.string.isRequired,
+    jobType: PropTypes.string,
+    setSearchValue: PropTypes.func.isRequired,
+    setJobDuration: PropTypes.func.isRequired,
+    setJobType: PropTypes.func.isRequired,
+    fields: PropTypes.array.isRequired,
+    technologies: PropTypes.array.isRequired,
+    showJobDurationSlider: PropTypes.bool.isRequired,
+    setFields: PropTypes.func.isRequired,
+    setTechs: PropTypes.func.isRequired,
+    setShowJobDurationSlider: PropTypes.func.isRequired,
+    jobDuration: PropTypes.number,
+    filterJobDuration: PropTypes.bool,
+};
 
 describe("SearchArea", () => {
     let onSubmit;
@@ -34,16 +77,8 @@ describe("SearchArea", () => {
         it("should render a Paper, a Form, a Search Bar, a Search Button and Advanced Options Button", () => {
             renderWithStoreAndTheme(
                 <RouteWrappedContent>
-                    <SearchArea
+                    <SearchAreaWrapper
                         onSubmit={onSubmit}
-                        fields={[]}
-                        technologies={[]}
-                        setShowJobDurationSlider={() => { }}
-                        setTechs={() => { }}
-                        setJobDuration={() => { }}
-                        setFields={() => { }}
-                        setJobType={() => { }}
-                        setSearchValue={() => { }}
                     />
                 </RouteWrappedContent>,
                 { initialState, theme }
@@ -54,6 +89,88 @@ describe("SearchArea", () => {
             expect(screen.getByRole("textbox", { name: "Search" })).toBeInTheDocument();
             expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
             expect(screen.getByRole("button", { name: "Toggle Advanced Search" })).toBeInTheDocument();
+        });
+        it("should render a text='Show All' in the default state of searchArea", () => {
+            const searchArea = renderWithStoreAndTheme(
+                <RouteWrappedContent>
+                    <SearchAreaWrapper />
+                </RouteWrappedContent>,
+                { initialState, theme }
+            );
+
+            expect(searchArea.getByRole("button", { name: "Search" })).toHaveTextContent("Show All");
+        });
+        it("should render a text='Search' when search bar value != ''", () => {
+            const searchArea = renderWithStoreAndTheme(
+                <RouteWrappedContent>
+                    <SearchAreaWrapper
+                        searchValue={"somevalue"}
+                    />
+                </RouteWrappedContent>,
+                { initialState, theme }
+            );
+
+            expect(searchArea.getByRole("button", { name: "Search" })).toHaveTextContent("Search");
+        });
+        it("should render a text='Show All' when search bar has undefined value", () => {
+            const searchArea = renderWithStoreAndTheme(
+                <RouteWrappedContent>
+                    <SearchAreaWrapper
+                        searchValue={undefined}
+                    />
+                </RouteWrappedContent>,
+                { initialState, theme }
+            );
+
+            expect(searchArea.getByRole("button", { name: "Search" })).toHaveTextContent("Show All");
+        });
+        it("should render a text='Search' when fields != []", () => {
+            const searchArea = renderWithStoreAndTheme(
+                <RouteWrappedContent>
+                    <SearchAreaWrapper
+                        fields={["field1", "field2"]}
+                    />
+                </RouteWrappedContent>,
+                { initialState, theme }
+            );
+
+            expect(searchArea.getByRole("button", { name: "Search" })).toHaveTextContent("Search");
+        });
+        it("should render a text='Search' when technologies != []", () => {
+            const searchArea = renderWithStoreAndTheme(
+                <RouteWrappedContent>
+                    <SearchAreaWrapper
+                        technologies={["tech1", "tech2"]}
+                    />
+                </RouteWrappedContent>,
+                { initialState, theme }
+            );
+
+            expect(searchArea.getByRole("button", { name: "Search" })).toHaveTextContent("Search");
+        });
+        it("should render a text='Search' when jobType != INITIAL_JOB_TYPE", () => {
+            const searchArea = renderWithStoreAndTheme(
+                <RouteWrappedContent>
+                    <SearchAreaWrapper
+                        jobType={"JOB"}
+                    />
+                </RouteWrappedContent>,
+                { initialState, theme }
+            );
+
+            expect(searchArea.getByRole("button", { name: "Search" })).toHaveTextContent("Search");
+        });
+        it("should render a text='Search' when showJobDurationSlider = true ", () => {
+            const searchArea = renderWithStoreAndTheme(
+                <RouteWrappedContent>
+                    <SearchAreaWrapper
+                        showJobDurationSlider={true}
+                    />
+                </RouteWrappedContent>,
+                { initialState, theme }
+            );
+
+            expect(searchArea.getByRole("button", { name: "Search" })).toHaveTextContent("Search");
         });
     });
 
@@ -124,15 +241,13 @@ describe("SearchArea", () => {
 
             renderWithStoreAndTheme(
                 <RouteWrappedContent url={url}>
-                    <SearchArea
+                    <SearchAreaWrapper
                         onSubmit={onSubmit}
                         setSearchValue={setSearchValue}
                         setJobType={setJobType}
                         setJobDuration={setJobDuration}
                         setShowJobDurationSlider={setShowJobDurationSlider}
-                        fields={[]}
                         setFields={setFields}
-                        technologies={[]}
                         setTechs={setTechs}
                     />
                 </RouteWrappedContent>,

--- a/src/components/HomePage/SearchArea/SubmitSearchButton.js
+++ b/src/components/HomePage/SearchArea/SubmitSearchButton.js
@@ -15,8 +15,11 @@ const SubmitSearchButton = ({ onClick, searchHasUserInput }) => {
                 variant="extended"
                 onClick={onClick}
             >
-                { searchHasUserInput ? <span>Search</span>
-                    : <span>Search All</span> }
+                <span>
+                    {searchHasUserInput
+                        ? "Search"
+                        : "Show All"}
+                </span>
             </Fab>
         </div>
     );

--- a/src/components/HomePage/SearchArea/SubmitSearchButton.js
+++ b/src/components/HomePage/SearchArea/SubmitSearchButton.js
@@ -2,27 +2,29 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { Fab } from "@material-ui/core";
-import { Search } from "@material-ui/icons";
 
 import useSearchAreaStyle from "./searchAreaStyle";
 
-const ShowAdvancedOptionsButton = ({ onClick }) => {
+const SubmitSearchButton = ({ onClick, searchHasUserInput }) => {
     const classes = useSearchAreaStyle();
     return (
         <div className={classes.submitSearchButtonWrapper}>
             <Fab
                 color="primary"
                 aria-label="Search"
+                variant="extended"
                 onClick={onClick}
             >
-                <Search />
+                { searchHasUserInput ? <span>Search</span>
+                    : <span>Search All</span> }
             </Fab>
         </div>
     );
 };
 
-ShowAdvancedOptionsButton.propTypes = {
+SubmitSearchButton.propTypes = {
     onClick: PropTypes.func.isRequired,
+    searchHasUserInput: PropTypes.bool.isRequired,
 };
 
-export default ShowAdvancedOptionsButton;
+export default SubmitSearchButton;

--- a/src/components/HomePage/SearchArea/SubmitSearchButton.spec.js
+++ b/src/components/HomePage/SearchArea/SubmitSearchButton.spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { Search } from "@material-ui/icons";
 import { Fab } from "@material-ui/core";
 import SubmitSearchButton from "./SubmitSearchButton";
 
@@ -10,9 +9,6 @@ describe("SubmitSearchButton", () => {
                 shallow(<SubmitSearchButton />)
                     .find(Fab).exists()
             ).toBe(true);
-        });
-        it("should render 'search' icon", () => {
-            expect(shallow(<SubmitSearchButton />).find(Search).exists()).toBe(true);
         });
     });
 

--- a/src/hooks/useComponentController.js
+++ b/src/hooks/useComponentController.js
@@ -3,7 +3,7 @@ import React from "react";
 export const DefaultContext = React.createContext();
 
 /**
- * This is based on the pattern described here: https://angeloteixeira.me/blog/reactive-controller-pattern
+ * This is based on the pattern described here: https://angeloteixeira.eu/blog/reactive-controller-pattern
  * With it, components can abstract logic common to different view layouts (such as desktop/mobile) and both can read from the given Context
  *
  * @param controller - A function (can be a React Hook) that handles some logic.


### PR DESCRIPTION
Closes #239.  The solution implemented was displaying a "search" button when there were no user specified filters nor any value in the search bar. Then, when the user chooses a filter or writes something in the search bar, it changes the button text to "search"


![image](https://user-images.githubusercontent.com/59887569/215916173-d36af0ca-f17e-48ee-87ed-08a933a0b28e.png)


![image](https://user-images.githubusercontent.com/59887569/215620381-88880d43-cfc7-4723-82e9-714712ff9b66.png)

![image](https://user-images.githubusercontent.com/59887569/215620467-aca56686-9bbd-4e3c-b1a4-1808cfb3ff88.png)


