### PR TITLE
aligned text with button

### DIFF
--- a/src/components/Offers/Form/form-components/OfferForm.js
+++ b/src/components/Offers/Form/form-components/OfferForm.js
@@ -337,7 +337,6 @@ const OfferForm = ({ context, title }) => {
                                             control={control}
                                             errors={errors.requirements || requestErrors.requirements}
                                             disabled={formDisabled}
-                                            textFieldProps={{ multiline: true }}
                                             addEntryBtnTestId="requirements-selector"
                                         />
                                     </Grid>

--- a/src/components/utils/form/MultiOptionTextField.js
+++ b/src/components/utils/form/MultiOptionTextField.js
@@ -6,6 +6,7 @@ import useMultiOptionTextFieldStyle from "./multiOptionTextFieldStyle";
 import PropTypes from "prop-types";
 
 const RemoveLineButton = ({ onClick, items, i }) => {
+    const classes = useMultiOptionTextFieldStyle();
     const disabled = Object.keys(items).length <= 1;
     return (
         <FormControl>
@@ -13,6 +14,7 @@ const RemoveLineButton = ({ onClick, items, i }) => {
                 <IconButton
                     aria-label={`Remove Entry ${i}`}
                     onClick={onClick}
+                    className={classes.buttom}
                     disabled={disabled}
                 >
                     <RemoveCircle />

--- a/src/components/utils/form/multiOptionTextFieldStyle.js
+++ b/src/components/utils/form/multiOptionTextFieldStyle.js
@@ -1,6 +1,9 @@
 import { makeStyles } from "@material-ui/styles";
 
 export default makeStyles(() => ({
+    buttom: {
+        bottom: "10px",
+    },
     addEntryBtn: {
         width: "max-content",
     },


### PR DESCRIPTION
According to the meeting I removed the textFieldProps={{ multiline: true }} option from the requirements textField and then adjusted the position of the remove entry button to align with the text.

Closes #262 